### PR TITLE
gracefully return when no ME directories can be found

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -6,6 +6,7 @@ use crate::{
         gen3::{CPD_MAGIC_BYTES, CodePartitionDirectory},
         man::Manifest,
     },
+    fpt::FPT_SIZE,
     fpt::{AFSP, DLMP, EFFS, FPT, FTPR, FTUP, MDMV, MFS, NFTP},
 };
 
@@ -14,12 +15,14 @@ pub enum Generation {
     Gen1,
     Gen2,
     Gen3,
+    Unknown,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Directories {
     Gen2(Vec<Gen2Directory>),
     Gen3(Vec<CodePartitionDirectory>),
+    Unknown,
 }
 
 #[allow(non_camel_case_types)]
@@ -115,7 +118,7 @@ impl ME {
                 } else if gen2dirs.len() > 0 {
                     (Generation::Gen2, Directories::Gen2(gen2dirs))
                 } else {
-                    return None;
+                    (Generation::Unknown, Directories::Unknown)
                 }
             };
 

--- a/src/show.rs
+++ b/src/show.rs
@@ -61,6 +61,8 @@ fn print_me(me: &ME) {
     match &me.dirs {
         Directories::Gen2(dirs) => print_gen2_dirs(dirs),
         Directories::Gen3(dirs) => print_gen3_dirs(dirs),
+        // TODO
+        _ => {}
     }
 }
 


### PR DESCRIPTION
This adds Unknown for both enums describing the ME generation and directories.