### PR TITLE
expose ranges instead of pair of usize for IFD regions

### DIFF
--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -44,7 +44,10 @@
 // Lowercase helpers are provided through implementations.
 #![allow(non_snake_case)]
 
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    ops::Range,
+};
 
 use bitfield_struct::bitfield;
 use serde::{Deserialize, Serialize};
@@ -307,8 +310,8 @@ impl FlashRegion {
         self.limit() as usize * 4096 + 4095
     }
 
-    pub fn range(self) -> (usize, usize) {
-        (self.ba(), self.la() + 1)
+    pub fn range(self) -> Range<usize> {
+        self.ba()..self.la() + 1
     }
 }
 
@@ -334,6 +337,18 @@ pub struct Regions {
     pub flreg7: FlashRegion,
     pub flreg8: FlashRegion,
     pub flreg9: FlashRegion,
+}
+
+impl Regions {
+    pub fn ifd_range(&self) -> Range<usize> {
+        self.flreg0.range()
+    }
+    pub fn bios_range(&self) -> Range<usize> {
+        self.flreg1.range()
+    }
+    pub fn me_range(&self) -> Range<usize> {
+        self.flreg2.range()
+    }
 }
 
 // NOTE: Regions have changed over processors generations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,10 @@ impl Firmware {
         let ifd = IFD::parse(&data);
         let me = match &ifd {
             Ok(ifd) => {
-                let me_region = ifd.regions.flreg2.range();
-                let (b, l) = me_region;
+                let me_region = ifd.regions.me_range();
+                let b = me_region.start;
                 info!("ME region start @ {b:08x}");
-                ME::parse(&data[b..l], b, debug)
+                ME::parse(&data[me_region], b, debug)
             }
             Err(e) => {
                 warn!("Not a full image: {e:?}");


### PR DESCRIPTION
Add helpers to get the IFD, BIOS and ME region, respectively.