### PR TITLE
CI: just use the ./book directory for Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,14 +26,11 @@ jobs:
           mdbook-version: "0.5.0"
 
       - name: Build
-        run: |
-          mdbook build
-          mkdir pages
-          mv book pages/
+        run: mdbook build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./pages
+          publish_dir: ./book

--- a/book.toml
+++ b/book.toml
@@ -5,4 +5,3 @@ title = "intel_fw"
 
 [output.html]
 git-repository-url = "https://github.com/platform-system-interface/intel_fw"
-site-url = "/book/"


### PR DESCRIPTION
The previous approach did not work. It was meant to enable later combination of mdBook with Rustdoc. However, there is a hint: https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-mdbook-rust
> put `./target/doc/` to your `./book/src` dir before you `mdbook build`

We will do that.